### PR TITLE
feat: Support qualified BCP47 languages

### DIFF
--- a/smartquotes.sile-dev-1.rockspec
+++ b/smartquotes.sile-dev-1.rockspec
@@ -14,6 +14,7 @@ description = {
 }
 dependencies = {
   "lua >= 5.1",
+  "silex.sile",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
Closes #1 

- [x] Implementation based on experimental silex
- [x] Add silex.sile dependency to the rockspec when available